### PR TITLE
GitHub Action to find Python syntax errors

### DIFF
--- a/.github/workflows/python_app.yml
+++ b/.github/workflows/python_app.yml
@@ -1,0 +1,26 @@
+name: Python application
+on: [push, pull_request]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - name: Set up Python 3.8
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.8
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install flake8 pytest
+        pip install -r requirements.txt || true
+    - name: Lint with flake8
+      run: |
+        # stop the build if there are Python syntax errors or undefined names
+        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+    - name: Test with pytest
+      run: |
+        pytest || true
+ 


### PR DESCRIPTION
__cmp()__ was removed in Python 3.
```python
./geometriq/grids.py:42:38: F821 undefined name 'cmp'
./geometriq/grids.py:50:30: F821 undefined name 'cmp'
./geometriq/grids.py:55:30: F821 undefined name 'cmp'
./geometriq/grids.py:59:38: F821 undefined name 'cmp'
./geometriq/shapes.py:55:16: F821 undefined name 'cmp'
```